### PR TITLE
Using the http git resource instead of ssh.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "definitions"]
 	path = definitions
-	url = git@github.com:royale-proxy/cr-messages.git
+	url = https://github.com/royale-proxy/cr-messages.git


### PR DESCRIPTION
Submodules won't work if it's using the ssh url. Use the https url so people like me who don't have access to your repo can still clone it.
